### PR TITLE
fix of addFilter method to work with arrays

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     }
   ],
   "require": {
-    "php": ">=7.1",
+    "php": ">=8.0",
     "guzzlehttp/guzzle": "7.*",
     "ext-mbstring": "*"
   },

--- a/phpunit.dist.xml
+++ b/phpunit.dist.xml
@@ -8,5 +8,6 @@
     <php>
         <env name="INSTANCE" value=""/>
         <env name="ACCESS_TOKEN" value=""/>
+        <env name="RECORD_TYPE" value=""/>
     </php>
 </phpunit>

--- a/src/DaktelaV6/Request/ReadRequest.php
+++ b/src/DaktelaV6/Request/ReadRequest.php
@@ -54,14 +54,14 @@ class ReadRequest extends ARequest
     /** @var string|null Variable containing the relation of the object to be returned when using the TYPE_MULTIPLE request type */
     private $relation = null;
 
-    /**
-     * Adds the filter to the current request type.
-     * @param string $field name of the field
-     * @param string $operator operator of the filter
-     * @param string $value value used for filtering
-     * @return $this current instance of the request to be used as builder pattern
-     */
-    public function addFilter(string $field, string $operator, string $value): self
+  /**
+   * Adds the filter to the current request type.
+   * @param string $field name of the field
+   * @param string $operator operator of the filter
+   * @param string|array $value value used for filtering
+   * @return $this current instance of the request to be used as builder pattern
+   */
+    public function addFilter(string $field, string $operator, string|array $value): self
     {
         $newFilter = ['field' => $field, 'operator' => $operator, 'value' => $value];
 

--- a/tests/DaktelaV6/Request/ReadRequestTest.php
+++ b/tests/DaktelaV6/Request/ReadRequestTest.php
@@ -51,6 +51,26 @@ class ReadRequestTest extends TestCase
         self::assertEquals($filters["filters"][1]["value"], "0");
     }
 
+  public function testAddSingleFilterWithArrayAsValue()
+  {
+    $request = new ReadRequest($this->url, $this->accessToken, "Tickets");
+
+    $request->addFilter("stage", "in", ["OPEN", "WAIT"]);
+    $filters = $request->getFilters();
+
+    self::assertArrayHasKey("logic", $filters);
+    self::assertArrayHasKey("filters", $filters);
+    self::assertCount(1, $filters["filters"]);
+    self::assertArrayHasKey("field", $filters["filters"][0]);
+    self::assertArrayHasKey("operator", $filters["filters"][0]);
+    self::assertArrayHasKey("value", $filters["filters"][0]);
+
+    self::assertEquals($filters["logic"], "and");
+    self::assertEquals($filters["filters"][0]["field"], "stage");
+    self::assertEquals($filters["filters"][0]["operator"], "in");
+    self::assertEquals($filters["filters"][0]["value"], ["OPEN", "WAIT"]);
+  }
+
     public function testAddFilterFromArray()
     {
         $request = new ReadRequest($this->url, $this->accessToken, "Users");


### PR DESCRIPTION
- replaced deprecated queue attribute with record type in campaignsRecords in tests (not supported since 6.19+)
- changed PHP version 7.1 -> 8.0 (to use union of types **string|array** )
- fixed addFilter method to accept also array as value
- added test which verifies that addFilter works