### PR TITLE
fixed addFilterFromArray method to accept also array as value in short-hand notation

### DIFF
--- a/src/DaktelaV6/Request/ReadRequest.php
+++ b/src/DaktelaV6/Request/ReadRequest.php
@@ -240,7 +240,7 @@ class ReadRequest extends ARequest
             if (is_array($filter)
                 && count($filter) == 3
                 && array_key_exists(0, $filter) && array_key_exists(1, $filter) && array_key_exists(2, $filter)
-                && is_string($filter[0]) && is_string($filter[1]) && is_string($filter[2])
+                && is_string($filter[0]) && is_string($filter[1]) && (is_string($filter[2]) || is_array($filter[2]))
             ) {
                 $filter["field"] = $filter[0];
                 $filter["operator"] = $filter[1];

--- a/tests/DaktelaV6/Request/ReadRequestTest.php
+++ b/tests/DaktelaV6/Request/ReadRequestTest.php
@@ -102,6 +102,32 @@ class ReadRequestTest extends TestCase
         self::assertEquals($filters["filters"][1]["value"], "0");
     }
 
+  public function testAddShortHandFilterWithArrayFromArray()
+  {
+    $request = new ReadRequest($this->url, $this->accessToken, "Users");
+
+    $filters = [
+      ["type", "in", ["SMS", "EMAIL", "CALL"]],
+    ];
+
+    $request->addFilterFromArray($filters);
+    $filters = $request->getFilters();
+
+    self::assertArrayHasKey("logic", $filters);
+    self::assertArrayHasKey("filters", $filters);
+    self::assertCount(1, $filters["filters"]);
+    self::assertArrayHasKey("field", $filters["filters"][0]);
+    self::assertArrayHasKey("operator", $filters["filters"][0]);
+    self::assertArrayHasKey("value", $filters["filters"][0]);
+
+    self::assertEquals($filters["logic"], "and");
+    self::assertEquals($filters["filters"][0]["field"], "type");
+    self::assertEquals($filters["filters"][0]["operator"], "in");
+    self::assertEquals($filters["filters"][0]["value"][0], "SMS");
+    self::assertEquals($filters["filters"][0]["value"][1], "EMAIL");
+    self::assertEquals($filters["filters"][0]["value"][2], "CALL");
+  }
+
     public function testAddOrFilterFromArray()
     {
         $request = new ReadRequest($this->url, $this->accessToken, "Users");


### PR DESCRIPTION
fixed addFilterFromArray method to accept also array as value in short-hand filter, added test which verifies that addFilterFromArray works
This works now: 
    $filters = [
      ["type", "in", ["SMS", "EMAIL", "CALL"]],
    ];