### PR TITLE
Add GitHub CI setup

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: Tests
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        php-version:
+          - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
+          - '8.4'
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: mbstring
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --prefer-dist --no-progress --no-interaction
+
+      - name: Run PHPUnit tests
+        run: vendor/bin/phpunit --configuration phpunit.dist.xml

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,6 +17,7 @@ jobs:
           - '8.2'
           - '8.3'
           - '8.4'
+          - '8.5'
 
     steps:
       - name: Checkout code

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "ext-mbstring": "*"
   },
   "require-dev": {
-    "phpunit/phpunit": "9.4.3",
+    "phpunit/phpunit": "^9.6",
     "phpstan/phpstan": "0.12.54",
     "squizlabs/php_codesniffer": "3.5.8"
   },


### PR DESCRIPTION
Configuration for running PHPUnit tests on PHP versions 8.0 to 8.4. The new workflow (.github/workflows/tests.yml) enables automatic verification of library compatibility across multiple PHP versions, simplifying development and ensuring stability across environments. During each CI run, the project is built, dependencies are installed, and tests are executed for all specified PHP versions, helping to detect issues early and improve code quality.